### PR TITLE
Fix capitalization in source-url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,6 @@
 {
   "name" : "HTTP::MultiPartParser",
-  "source-url" : "git://github.com/tokuhirom/p6-HTTP-MultipartParser.git",
+  "source-url" : "git://github.com/tokuhirom/p6-HTTP-MultiPartParser.git",
   "perl" : "v6",
   "provides" : {
     "HTTP::MultiPartParser" : "lib/HTTP/MultiPartParser.pm6"


### PR DESCRIPTION
We're adding Travis badgest to modules.perl6.org and I noticed incorrect capitalization makes the badge lookup for this distro fail because travis can't find the distro.
