### PR TITLE
Removing leading 'v' from meta info

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name" : "HTTP::MultiPartParser",
   "source-url" : "git://github.com/tokuhirom/p6-HTTP-MultiPartParser.git",
-  "perl" : "v6",
+  "perl" : "6",
   "provides" : {
     "HTTP::MultiPartParser" : "lib/HTTP/MultiPartParser.pm6"
   },


### PR DESCRIPTION
It's a minor change, but this shows up when I'm installing from Panda:

==> Fetching HTTP::MultiPartParser
Please remove leading 'v' from perl version in HTTP::MultiPartParser's meta info.

Trivial, and I probably have to fix it in my own stuff as well, but I thought
I'd let you know.
