### PR TITLE
use JSON::Fast to remove deprecation warning

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,7 @@
   "provides" : {
     "HTTP::MultiPartParser" : "lib/HTTP/MultiPartParser.pm6"
   },
-  "depends" : [ ],
+  "depends" : [ "JSON::Fast" ],
   "description" : "",
   "version" : "*",
   "authors" : [

--- a/t/030_basic.t
+++ b/t/030_basic.t
@@ -1,6 +1,7 @@
 use v6;
 
 use Test;
+use JSON::Fast;
 
 use HTTP::MultiPartParser;
 


### PR DESCRIPTION
```
Saw 1 occurrence of deprecated code.
================================================================================
Sub from-json (from GLOBAL) seen at:
  t/030_basic.t, lines 12,13
Please use JSON::Fast, JSON::Tiny or JSON::Pretty from https://modules.perl6.org/ instead.
--------------------------------------------------------------------------------
Please contact the author to have these occurrences of deprecated code
adapted, so that this message will disappear!
```
