### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name" : "HTTP::MultiPartParser",
+  "license" : "Artistic-2.0",
   "description" : "low level multipart/form-data parser",
   "source-url" : "git://github.com/tokuhirom/p6-HTTP-MultiPartParser.git",
   "perl" : "6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license